### PR TITLE
Add support for outputting adsorbate heights

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ slab, molecules, labels = sf.predict(real_surface_1)
 This returns three outputs:
 1. `slab`: The clean surface geometry as an `ase.Atoms`, without any adsorbates.
 2. `molecules`: A list of `ase.Atoms` representing the adsorbates and gas phase molecules found on and above the surface respectively.
-3. `labels`: A list of dictionaries corresponding to the entries in `molecules` containing the atoms of the respective adsorbate that are adsorbed onto the surface and their predicted sites.
+3. `labels`: A list of dictionaries corresponding to the entries in `molecules` containing the atoms of the respective adsorbate that are adsorbed onto the surface, their predicted sites and the adsorption heights above those sites.
 
 For example, given the above system:
 
@@ -168,9 +168,9 @@ for molecule, label in zip(molecules, labels):
 ```
 
 ```
-Atoms(symbols='OCH3', pbc=False, tags=...) {0: {'site': 'Au_fcc111_fcc', 'bonded_elem': 'O', 'coordination': 3}}
-Atoms(symbols='OCH3', pbc=False, tags=...) {0: {'site': 'Au_fcc111_fcc', 'bonded_elem': 'O', 'coordination': 3}}
-Atoms(symbols='OCH3', pbc=False, tags=...) {0: {'site': 'Au_fcc111_fcc', 'bonded_elem': 'O', 'coordination': 3}}
+Atoms(symbols='OCH3', pbc=False, tags=...) {0: {'site': 'Au_fcc111_fcc', 'bonded_elem': 'O', 'coordination': 3, 'height': 1.7941429100000015}}
+Atoms(symbols='OCH3', pbc=False, tags=...) {0: {'site': 'Au_fcc111_fcc', 'bonded_elem': 'O', 'coordination': 3, 'height': 1.79542644}}
+Atoms(symbols='OCH3', pbc=False, tags=...) {0: {'site': 'Au_fcc111_fcc', 'bonded_elem': 'O', 'coordination': 3, 'height': 1.7944157000000018}}
 Atoms(symbols='CHOH3', pbc=False, tags=...) {}
 ```
 
@@ -195,9 +195,9 @@ for molecule, label in zip(molecules, labels):
 ```
 
 ```
-Atoms(symbols='CO', pbc=False) {0: {'site': 'Au_fcc111_ontop', 'bonded_elem': 'C', 'coordination': 1}}
-Atoms(symbols='OH', pbc=False) {0: {'site': 'Au_fcc111_fcc', 'bonded_elem': 'O', 'coordination': 3}}
-Atoms(symbols='NHCH3', pbc=False) {0: {'site': 'Au_fcc111_bridge', 'bonded_elem': 'N', 'coordination': 2}}
+Atoms(symbols='CO', pbc=False) {0: {'site': 'Au_fcc111_ontop', 'bonded_elem': 'C', 'coordination': 1, 'height': 2.4249690500000014}}
+Atoms(symbols='OH', pbc=False) {0: {'site': 'Au_fcc111_fcc', 'bonded_elem': 'O', 'coordination': 3, 'height': 1.7710107300000004}}
+Atoms(symbols='NHCH3', pbc=False) {0: {'site': 'Au_fcc111_bridge', 'bonded_elem': 'N', 'coordination': 2, 'height': 1.9164665700000008}}
 ```
 
 #### A note on adsorbate identification

--- a/asesurfacefinder/asesf.py
+++ b/asesurfacefinder/asesf.py
@@ -315,10 +315,10 @@ class SurfaceFinder:
         # Predict surface sites.
         pos = ads_slab.get_positions()
         slab = ads_slab[slabatom_slabidxs]
-        if ads_slab.info.get('top layer atom index') is None:
+        if ads_slab.info.get('adsorbate_info') is None and ads_slab.info['adsorbate_info'].get('top layer atom index') is None:
             slab_max_z = slab.positions[:, 2].max()
         else:
-            slab_max_z = ads_slab.positions[ads_slab.info['top layer atom index'], 2]
+            slab_max_z = ads_slab.positions[ads_slab.info['adsorbate_info']['top layer atom index'], 2]
         bonded_positions = pos[bonded_molatom_slabidxs]
         descs = self.desc.create(slab, bonded_positions, n_jobs=self.clf.n_jobs)
         pred_labels = self.clf.predict(descs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asesurfacefinder"
-version = "1.0.2"
+version = "1.0.3"
 description = "Machine learned location of chemical adsorbates on high-symmetry surface sites."
 readme = "README.md"
 authors = [{ name = "Joe Gilkes", email = "joe@joegilk.es" }]


### PR DESCRIPTION
While predicting, measures height of adsorbed atoms above the surface. 

To maintain compatibility with ASE's definition of 'height', this determines a 'surface height' from the marked atom in `atoms.info['adsorbate_info']['top layer atom index']` or, failing that, the maximum z-position of the slab atoms. This is subtracted from the z-position of each adsorbed atom to yield a height above the surface, relative to the 'surface height'.