### PR TITLE
Fix errors on non-adsorbed surfaces

### DIFF
--- a/asesurfacefinder/asesf.py
+++ b/asesurfacefinder/asesf.py
@@ -319,9 +319,11 @@ class SurfaceFinder:
             slab_max_z = slab.positions[:, 2].max()
         else:
             slab_max_z = ads_slab.positions[ads_slab.info['adsorbate_info']['top layer atom index'], 2]
-        bonded_positions = pos[bonded_molatom_slabidxs]
-        descs = self.desc.create(slab, bonded_positions, n_jobs=self.clf.n_jobs)
-        pred_labels = self.clf.predict(descs)
+        # Only predict if there are actually adsorbed atoms.
+        if len(bonded_molatom_slabidxs) > 0:
+            bonded_positions = pos[bonded_molatom_slabidxs]
+            descs = self.desc.create(slab, bonded_positions, n_jobs=self.clf.n_jobs)
+            pred_labels = self.clf.predict(descs)
 
         # Assign surface sites to molecules.
         slabidx_to_molidx = {int(idx): i for i, idx in enumerate(molatom_slabidxs)}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asesurfacefinder"
-version = "1.0.4"
+version = "1.0.5"
 description = "Machine learned location of chemical adsorbates on high-symmetry surface sites."
 readme = "README.md"
 authors = [{ name = "Joe Gilkes", email = "joe@joegilk.es" }]


### PR DESCRIPTION
Surfaces without any directly bonded adsorbates, but with gas-phase species above the surface, should not cause errors. ASESurfaceFinder should still be able to identify these systems and separate out the gas-phase molecules, just without doing any predictions or providing any labels.

This fixes these errors by only running predictions if any bonded adsorbate atoms are located.