### PR TITLE
Add passthrough for `NeighborList` cutoffs to `SurfaceFinder.predict()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 asesurfacefinder.egg-info
 dist
+build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asesurfacefinder"
-version = "1.0.5"
+version = "1.0.6"
 description = "Machine learned location of chemical adsorbates on high-symmetry surface sites."
 readme = "README.md"
 authors = [{ name = "Joe Gilkes", email = "joe@joegilk.es" }]


### PR DESCRIPTION
When working with more approximate electronic structure methods and forcefields, sometimes the maximum bonding distance of adsorbates above a surface needs to be increased to account for higher adsorption geometries.

This has been allowed by optionally passing `nl_cutoffs` to `SurfaceFinder.predict()`, which defaults to the normal `ase.neighborlist.natural_cutoffs(atoms)` but can be augmented using e.g. `natural_cutoffs(atoms, mult=1.2)`.

The way that neighbours are counted has also been improved to be more resilient and responsive to this change.