### PR TITLE
Fix coordination counting of surface sites

### DIFF
--- a/asesurfacefinder/asesf.py
+++ b/asesurfacefinder/asesf.py
@@ -297,10 +297,11 @@ class SurfaceFinder:
         ana = Analysis(ads_slab, cutoffs=cutoffs, self_interaction=False, bothways=True)
         nl = ana.nl[0]
         bonded_molatom_slabidxs = []
-        for molatom_slabidx in molatom_slabidxs:
-            molatom_neighbors, _ = nl.get_neighbors(molatom_slabidx)
-            if np.any([slabatom_slabidx in molatom_neighbors for slabatom_slabidx in slabatom_slabidxs]):
-                bonded_molatom_slabidxs.append(molatom_slabidx)
+        for slabatom_slabidx in slabatom_slabidxs:
+            slabatom_neighbors, _ = nl.get_neighbors(slabatom_slabidx)
+            for molatom_slabidx in molatom_slabidxs:
+                if molatom_slabidx in slabatom_neighbors:
+                    bonded_molatom_slabidxs.append(molatom_slabidx)
 
         bonded_molatom_slabidxs, bonded_molatom_coordinations = np.unique(bonded_molatom_slabidxs, return_counts=True)
         if self.verbose: print(f'  {len(bonded_molatom_slabidxs)} adsorbed atoms found on surface at idxs {bonded_molatom_slabidxs}.')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asesurfacefinder"
-version = "1.0.6"
+version = "1.0.7"
 description = "Machine learned location of chemical adsorbates on high-symmetry surface sites."
 readme = "README.md"
 authors = [{ name = "Joe Gilkes", email = "joe@joegilk.es" }]


### PR DESCRIPTION
#4 created a bug where all surface sites were being identified with a coordination of 1 on prediction. This corrects coordination counting by looking for matches of adsorbate atoms from surface atoms, rather than the other way around.