### PR TITLE
Improve sampling volumes above surface sites

### DIFF
--- a/asesurfacefinder/__init__.py
+++ b/asesurfacefinder/__init__.py
@@ -1,2 +1,3 @@
 from asesurfacefinder.asesf import SurfaceFinder
+from asesurfacefinder.sample_bounds import SampleBounds
 from asesurfacefinder.plot import SamplePlotter

--- a/asesurfacefinder/asesf.py
+++ b/asesurfacefinder/asesf.py
@@ -89,7 +89,7 @@ class SurfaceFinder:
               samples_per_site: int=500,
               surf_mults: Sequence[tuple[int, int, int]]=[(1,1,1)],
               ads_z_bounds: tuple[float, float]=(1.2, 2.75),
-              ads_xy_noise: float=1e-2,
+              ads_r_max: float=1e-2,
               n_jobs: int=1
         ):
         '''Trains a random forest classifier to recognise surface sites.
@@ -98,7 +98,7 @@ class SurfaceFinder:
             samples_per_site: Number of adsorbate positions to sample on each surface site during training.
             surf_mults: (X,Y,Z) surface supercell multipliers to sample.
             ads_z_bounds: Tuple of minimum and maximum heights to train for adsorbates binding to surface sites.
-            ads_xy_noise: XY-plane noise to add to sampled adsorbate position during training.
+            ads_r_max: Maximum radius from adsorbate position to sample during training.
             n_jobs: Number of processes to parallelise descriptor generation and training over.
         '''
         if self.verbose:
@@ -121,7 +121,7 @@ class SurfaceFinder:
                     site_abspos = get_absolute_abspos(surface, site)
                     for l in range(samples_per_site):
                         slab = surface.copy()
-                        xy, z = sample_ads_pos(site_abspos, ads_z_bounds, ads_xy_noise)
+                        xy, z = sample_ads_pos(site_abspos, ads_z_bounds, ads_r_max)
                         add_adsorbate(slab, 'H', z, xy)
                         slab_positions[(k*samples_per_site)+l, :] = slab.get_positions()[-1]
                         labels.append(f'{label}_{site}')
@@ -151,7 +151,7 @@ class SurfaceFinder:
                  samples_per_site: int=500,
                  surf_mults: Sequence[tuple[int, int, int]]=[(1,1,1), (2,2,1)],
                  ads_z_bounds: tuple[float, float]=(1.3, 2.7),
-                 ads_xy_noise: float=1e-2
+                 ads_r_max: float=1e-2
         ):
         '''Validates a random forest classifier's ability to recognise surface sites.
         
@@ -159,7 +159,7 @@ class SurfaceFinder:
             samples_per_site: Number of adsorbate positions to sample on each surface site during validation.
             surf_mults: (X,Y,Z) surface supercell multipliers to sample.
             ads_z_bounds: Tuple of minimum and maximum heights to validate for adsorbates binding to surface sites.
-            ads_xy_noise: XY-plane noise to add to sampled adsorbate position during validation.
+            ads_r_max: Maximum radius from adsorbate position to sample during validation.
         '''
         if self.verbose: 
             print('ASESurfaceFinder Validation')
@@ -186,7 +186,7 @@ class SurfaceFinder:
                     site_abspos = get_absolute_abspos(surface, site)
                     for l in range(samples_per_site):
                         slab = surface.copy()
-                        xy, z = sample_ads_pos(site_abspos, ads_z_bounds, ads_xy_noise)
+                        xy, z = sample_ads_pos(site_abspos, ads_z_bounds, ads_r_max)
                         add_adsorbate(slab, 'H', z, xy)
                         slab_positions[(k*samples_per_site)+l, :] = slab.get_positions()[-1]
                         labels.append(f'{label}_{site}')
@@ -221,7 +221,7 @@ class SurfaceFinder:
         if len(incorrect_idxs) > 0:
             stat_labels = []
             for i in incorrect_idxs:
-                stat_labels.append(f'{labels[i]} {smults[i]} (h = {heights[i]:.2f}, d = {displacements[i]:.2f})')
+                stat_labels.append(f'{labels[i]} {smults[i]} (h = {heights[i]:.2f}, r = {displacements[i]:.2f})')
 
             stat_clen = np.max([len(lab) for lab in stat_labels])
             print(f'True {" "*(stat_clen-5)} | Predicted')

--- a/asesurfacefinder/asesf.py
+++ b/asesurfacefinder/asesf.py
@@ -167,7 +167,7 @@ class SurfaceFinder:
     def validate(self,
                  samples_per_site: int=500,
                  surf_mults: Sequence[tuple[int, int, int]]=[(1,1,1), (2,2,1)],
-                 sample_bounds: Sequence[dict]=None
+                 sample_bounds: Sequence[dict]=[]
         ):
         '''Validates a random forest classifier's ability to recognise surface sites.
         
@@ -206,7 +206,7 @@ class SurfaceFinder:
                         bounds = sample_bounds[i][site]
                     else:
                         bounds = self.sample_bounds[i][site]
-                        
+
                     for l in range(samples_per_site):
                         slab = surface.copy()
                         xy, z = sample_ads_pos(site_abspos, bounds.z_bounds, bounds.r_max)

--- a/asesurfacefinder/asesf.py
+++ b/asesurfacefinder/asesf.py
@@ -7,6 +7,7 @@ from ase.neighborlist import natural_cutoffs
 from scipy import sparse
 
 from asesurfacefinder.utils import *
+from asesurfacefinder.sample_bounds import SampleBounds
 from asesurfacefinder.exception import *
 
 from ase import Atoms
@@ -18,8 +19,10 @@ from dscribe.descriptors.descriptorlocal import DescriptorLocal
 class SurfaceFinder:
     def __init__(self, surfaces: Sequence[Atoms], 
                  labels: Sequence[str]=None,
+                 sample_bounds: Sequence[dict]=[],
                  clf: RandomForestClassifier=None,
                  descriptor: Union[DescriptorLocal, str]='SOAP',
+                 sample_defaults: SampleBounds = SampleBounds(0.1, 1.0, 2.75),
                  verbose: bool=True):
         '''Predicts location of adsorbates on surfaces.
         
@@ -27,6 +30,12 @@ class SurfaceFinder:
         high-symmetry adsorption points, trains a random forest
         classification model to predict the high-symmetry point
         that adsorbates are bound to.
+
+        Each surface can take a dictionary of `SampleBounds` that
+        defines the volume above each surface site in which 
+        adsorption points are sampled during training. If this is
+        not provided for a particular surface/site, this falls
+        back to the bounds in `sample_defaults`.
 
         Can evaluate its own performance on generated surface/adsorbate
         examples in a secondary validation step.
@@ -38,8 +47,10 @@ class SurfaceFinder:
         Arguments:
             surfaces: List of ASE `Atoms` objects representing surfaces with correctly maped high-symmetry adsorption points.
             labels: Optional list of names for surfaces, must be of equal length to `surfaces` if provided.
+            sample_bounds: Optional list of dicts specifying `SampleBounds` instances for each surface site.
             clf: Optional `RandomForestClassifier` instance.
             descriptor: Optional local descriptor type, must be one of ['SOAP', 'LMBTR'] or an instantiated generator fron DScribe.
+            sample_defaults: Default `SampleBounds` to fall back on when one is not specified for a site in `sample_bounds`.
             verbose: Whether to print information to stdout.
         '''
         if labels == None:
@@ -48,10 +59,14 @@ class SurfaceFinder:
             raise ValueError('Incorrect number of labels for provided number of surfaces.')
         else:
             self.labels = labels
+
+        if len(sample_bounds) != 0 and len(sample_bounds) != len(surfaces):
+            raise ValueError('Incorrect number of sample bounds dicts for provided number of surfaces.')
         
         self.elements = []
         self.surface_sites = []
         self.surfaces = []
+        self.sample_bounds = [{} for _ in range(len(surfaces))]
         for i, surface in enumerate(surfaces):
             for elem in surface.get_chemical_symbols():
                 if elem not in self.elements:
@@ -64,6 +79,11 @@ class SurfaceFinder:
             
             sites = info['sites'].keys()
             self.surface_sites.append(sites)
+            for site in sites:
+                if len(sample_bounds) == 0 or site not in sample_bounds[i].keys():
+                    self.sample_bounds[i][site] = sample_defaults
+                else:
+                    self.sample_bounds[i][site] = sample_bounds[i][site]
             
             if sum(surface.cell[2]) == 0.0:
                 surface.center(10.0, axis=2)
@@ -88,8 +108,6 @@ class SurfaceFinder:
     def train(self, 
               samples_per_site: int=500,
               surf_mults: Sequence[tuple[int, int, int]]=[(1,1,1)],
-              ads_z_bounds: tuple[float, float]=(1.2, 2.75),
-              ads_r_max: float=1e-2,
               n_jobs: int=1
         ):
         '''Trains a random forest classifier to recognise surface sites.
@@ -97,8 +115,6 @@ class SurfaceFinder:
         Arguments:
             samples_per_site: Number of adsorbate positions to sample on each surface site during training.
             surf_mults: (X,Y,Z) surface supercell multipliers to sample.
-            ads_z_bounds: Tuple of minimum and maximum heights to train for adsorbates binding to surface sites.
-            ads_r_max: Maximum radius from adsorbate position to sample during training.
             n_jobs: Number of processes to parallelise descriptor generation and training over.
         '''
         if self.verbose:
@@ -121,7 +137,8 @@ class SurfaceFinder:
                     site_abspos = get_absolute_abspos(surface, site)
                     for l in range(samples_per_site):
                         slab = surface.copy()
-                        xy, z = sample_ads_pos(site_abspos, ads_z_bounds, ads_r_max)
+                        bounds = self.sample_bounds[i][site]
+                        xy, z = sample_ads_pos(site_abspos, bounds.z_bounds, bounds.r_max)
                         add_adsorbate(slab, 'H', z, xy)
                         slab_positions[(k*samples_per_site)+l, :] = slab.get_positions()[-1]
                         labels.append(f'{label}_{site}')
@@ -150,22 +167,23 @@ class SurfaceFinder:
     def validate(self,
                  samples_per_site: int=500,
                  surf_mults: Sequence[tuple[int, int, int]]=[(1,1,1), (2,2,1)],
-                 ads_z_bounds: tuple[float, float]=(1.3, 2.7),
-                 ads_r_max: float=1e-2
+                 sample_bounds: Sequence[dict]=None
         ):
         '''Validates a random forest classifier's ability to recognise surface sites.
         
         Arguments:
             samples_per_site: Number of adsorbate positions to sample on each surface site during validation.
-            surf_mults: (X,Y,Z) surface supercell multipliers to sample.
-            ads_z_bounds: Tuple of minimum and maximum heights to validate for adsorbates binding to surface sites.
-            ads_r_max: Maximum radius from adsorbate position to sample during validation.
+            surf_mults: Optional (X,Y,Z) surface supercell multipliers to sample.
+            sample_bounds: Optional list of dicts that can override the `SampleBounds` used in training.
         '''
         if self.verbose: 
             print('ASESurfaceFinder Validation')
             print('------------------------------------')
         if not hasattr(self, 'clf'):
             raise AttributeError('No trained RandomForestClassifier found.')
+        
+        if len(sample_bounds) != 0 and len(sample_bounds) != len(self.surfaces):
+            raise ValueError('Incorrect number of sample bounds dicts for trained number of surfaces.')
         
         n_mults = len(surf_mults)
         n_samples = sum([n_mults*len(sites)*samples_per_site for sites in self.surface_sites])
@@ -184,9 +202,14 @@ class SurfaceFinder:
 
                 for k, site in enumerate(sites):
                     site_abspos = get_absolute_abspos(surface, site)
+                    if len(sample_bounds) != 0 and site in sample_bounds[i].keys():
+                        bounds = sample_bounds[i][site]
+                    else:
+                        bounds = self.sample_bounds[i][site]
+                        
                     for l in range(samples_per_site):
                         slab = surface.copy()
-                        xy, z = sample_ads_pos(site_abspos, ads_z_bounds, ads_r_max)
+                        xy, z = sample_ads_pos(site_abspos, bounds.z_bounds, bounds.r_max)
                         add_adsorbate(slab, 'H', z, xy)
                         slab_positions[(k*samples_per_site)+l, :] = slab.get_positions()[-1]
                         labels.append(f'{label}_{site}')

--- a/asesurfacefinder/plot.py
+++ b/asesurfacefinder/plot.py
@@ -12,14 +12,14 @@ class SamplePlotter:
     def __init__(self, surface: Atoms,
                  samples_per_site: int=500,
                  ads_z_bounds: tuple[float, float]=(1.2, 2.75),
-                 ads_xy_noise: float=5e-2):
+                 ads_r_max: float=5e-2):
         '''Samples surface sites and plots adsorbate positions.
         
         Arguments:
             surface: ASE surface to sample.
             samples_per_site: Number of adsorbate positions to sample on each surface site.
             ads_z_bounds: Tuple of minimum and maximum heights to train for adsorbates binding to surface sites.
-            ads_xy_noise: XY-plane noise to add to sampled adsorbate position during training.
+            ads_r_max: Maximum radius from adsorbate position to sample.
         '''
         self.surface = surface
         self.sites = surface.info['adsorbate_info']['sites'].keys()
@@ -35,7 +35,7 @@ class SamplePlotter:
         for i, site in enumerate(self.sites):
             site_abspos = get_absolute_abspos(surface, site)
             for _ in range(samples_per_site):
-                xy, z = sample_ads_pos(site_abspos, ads_z_bounds, ads_xy_noise)
+                xy, z = sample_ads_pos(site_abspos, ads_z_bounds, ads_r_max)
                 add_adsorbate(self.surface, self.atom_types[i], z, xy)
                 self.radii.append(ads_radius)
 

--- a/asesurfacefinder/plot.py
+++ b/asesurfacefinder/plot.py
@@ -5,21 +5,22 @@ from ase.data import covalent_radii, chemical_symbols
 from ase.data.colors import jmol_colors
 from matplotlib.lines import Line2D
 
+from asesurfacefinder.sample_bounds import SampleBounds
 from asesurfacefinder.utils import get_absolute_abspos, sample_ads_pos
 
 
 class SamplePlotter:
     def __init__(self, surface: Atoms,
                  samples_per_site: int=500,
-                 ads_z_bounds: tuple[float, float]=(1.2, 2.75),
-                 ads_r_max: float=5e-2):
+                 sample_bounds: dict={},
+                 sample_defaults:SampleBounds=SampleBounds(0.1, 1.0, 2.75)):
         '''Samples surface sites and plots adsorbate positions.
         
         Arguments:
             surface: ASE surface to sample.
             samples_per_site: Number of adsorbate positions to sample on each surface site.
-            ads_z_bounds: Tuple of minimum and maximum heights to train for adsorbates binding to surface sites.
-            ads_r_max: Maximum radius from adsorbate position to sample.
+            sample_bounds: Optional dict binding site names to `SampleBounds` instances.
+            sample_defaults: Default `SampleBounds` to fall back on when one is not specified for a site in `sample_bounds`.
         '''
         self.surface = surface
         self.sites = surface.info['adsorbate_info']['sites'].keys()
@@ -34,8 +35,9 @@ class SamplePlotter:
 
         for i, site in enumerate(self.sites):
             site_abspos = get_absolute_abspos(surface, site)
+            bounds = sample_bounds[site] if site in sample_bounds.keys() else sample_defaults
             for _ in range(samples_per_site):
-                xy, z = sample_ads_pos(site_abspos, ads_z_bounds, ads_r_max)
+                xy, z = sample_ads_pos(site_abspos, bounds.z_bounds, bounds.r_max)
                 add_adsorbate(self.surface, self.atom_types[i], z, xy)
                 self.radii.append(ads_radius)
 

--- a/asesurfacefinder/sample_bounds.py
+++ b/asesurfacefinder/sample_bounds.py
@@ -1,0 +1,17 @@
+class SampleBounds:
+    def __init__(self, r_max: float, z_min: float, z_max: float, z_mid: float=None):
+        if r_max < 0:
+            raise ValueError('Sampling r_max must be greater than or equal to zero.')
+        if z_mid is not None:
+            if not (z_min < z_mid and z_mid < z_max):
+                raise ValueError('Sampling Z-bounds incorrectly ordered, must be z_min < z_mid < z_max.')
+        else:
+            if not z_min < z_max:
+                raise ValueError('Sampling Z-bounds incorrectly ordered, must be z_min < z_max.')
+            
+        self.r_max = r_max
+        self.z_min = z_min
+        self.z_mid = z_mid
+        self.z_max = z_max
+        self.is_ovoid = False if z_mid is None else True
+        self.z_bounds = (self.z_min, self.z_mid, self.z_max) if self.is_ovoid else (self.z_min, self.z_max)

--- a/asesurfacefinder/utils.py
+++ b/asesurfacefinder/utils.py
@@ -30,20 +30,25 @@ def descgen_soap(elements: Sequence[str]):
     return soap
 
 
-def sample_ads_pos(xy_pos: ArrayLike, z_bounds: tuple[float, float], xy_noise: float):
+def sample_ads_pos(xy_pos: ArrayLike, z_bounds: tuple[float, float], r_max: float):
     '''Sample an adsorbate position.
-    
-    Given the absolute XY position of a high-symmetry point, samples
-    a new XY point by adding normally distributed random noise, and
-    an adsorption height from a uniform distribution between upper
-    and lower bounds.
+
+    Uniformly samples an XY position displaced from `xy_pos` within a 
+    circle of radius `r_max`. Samples a Z position uniformly within the
+    bounds defined by `z_bounds`, but scales the upper bound based on the
+    distance from the center of the circle to the edge to form a 
+    hemispheroidal sampling volume.
 
     Returns a tuple of new XY position and adsorption height.
     '''
-    new_xy_pos = np.copy(xy_pos)
-    new_xy_pos += np.random.normal(0.0, xy_noise, 2)
+    r = np.random.uniform(0, r_max)
+    theta = np.random.uniform(0, 2 * np.pi)
+    xy_sample = np.array([r * np.cos(theta), r * np.sin(theta)])
+    new_xy_pos = xy_pos + xy_sample
 
-    z = np.random.uniform(z_bounds[0], z_bounds[1])
+    z_diff = z_bounds[1] - z_bounds[0]
+    z_upper = max(z_bounds[0] + (np.sqrt(r_max**2 - r**2)/r_max)*z_diff, z_bounds[0])
+    z = np.random.uniform(z_bounds[0], z_upper)
 
     return new_xy_pos, z
 


### PR DESCRIPTION
Implements a `SurfaceBounds` class, which holds the sampling bounds for either a hemispheroid or an ovoid sampling volume.

A `SurfaceBounds` can be assigned to each site on each surface, or left unassigned to accept a default value. These bounds are then used for training and validation, although they can similarly be overridden on a site-by-site basis during validation.

These are similarly also used in `SamplePlotter` for visualising the sampling volumes. This will need good documentation for v1.1