### PR TITLE
Increased SamplePlotter speed

### DIFF
--- a/asesurfacefinder/plot.py
+++ b/asesurfacefinder/plot.py
@@ -1,9 +1,13 @@
 from ase import Atoms
 from ase.build import add_adsorbate
-from ase.visualize.plot import plot_atoms
+from ase.io.utils import PlottingVariables
 from ase.data import covalent_radii, chemical_symbols
 from ase.data.colors import jmol_colors
+
+import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
+from matplotlib.path import Path
+from matplotlib.patches import Circle, PathPatch
 
 from asesurfacefinder.sample_bounds import SampleBounds
 from asesurfacefinder.utils import get_absolute_abspos, sample_ads_pos
@@ -30,6 +34,8 @@ class SamplePlotter:
         self.ref_colors = [(rc[0], rc[1], rc[2], 1.0) for rc in self.ref_colors]
         self.plot_colors = [(0.9, 0.2, 0.2, 0.25), (0.2, 0.2, 0.9, 0.25), (0.2, 0.9, 0.2, 0.25), (0.9, 0.2, 0.9, 0.25)]
 
+        self.colors = [jmol_colors[i] for i in surface.get_atomic_numbers()]
+        self.remove_edgecolor_mask = [False for _ in surface]
         self.radii = [covalent_radii[n] for n in surface.get_atomic_numbers()]
         ads_radius = 0.02
 
@@ -40,6 +46,8 @@ class SamplePlotter:
                 xy, z = sample_ads_pos(site_abspos, bounds.z_bounds, bounds.r_max)
                 add_adsorbate(self.surface, self.atom_types[i], z, xy)
                 self.radii.append(ads_radius)
+                self.colors.append(self.plot_colors[i])
+                self.remove_edgecolor_mask.append(True)
 
         return
     
@@ -56,19 +64,62 @@ class SamplePlotter:
             ax: Optional matplotlib axes to plot on, creates one if not provided.
             **kwargs: Keyword arguments to pass to `plot_atoms`.
         '''
-        ax = plot_atoms(self.surface, ax=ax, radii=self.radii, **kwargs)
+        if ax is None:
+            ax = plt.gca()
+        Matplotlib(self.surface, ax, radii=self.radii, colors=self.colors, remove_edgecolor_mask=self.remove_edgecolor_mask, **kwargs).write()
+        
         n_sites = len(self.sites)
-        for patch in ax.patches:
-            c = patch.properties().get('facecolor', None)
-            for i, rc in enumerate(self.ref_colors):
-                if c == rc:
-                    patch.set_edgecolor((0.0, 0.0, 0.0, 0.0))
-                    patch.set_facecolor(self.plot_colors[i])
-                    continue
-
         legend_points = [Line2D([0], [0], marker='o', ls='', color=pc) for pc in self.plot_colors[:n_sites]]
         fig = ax.figure
         fig.legend(legend_points, self.sites, loc='lower center', ncols=n_sites)
         
         return ax
         
+# Reimplementation of ASE's matplotlib integration.
+# Cuts out a few bits we don't need to speed up plotting with thousands of points,
+# and allows for disabling edgecolors of sampled points during figure creation,
+# rather than modifying thousands of patches afterwards.
+class Matplotlib(PlottingVariables):
+    def __init__(self, atoms, ax, rotation='', radii=None,
+                 colors=None, remove_edgecolor_mask=None, 
+                 scale=1, offset=(0, 0), **parameters):
+        PlottingVariables.__init__(
+            self, atoms, rotation=rotation,
+            radii=radii, colors=colors, scale=scale,
+            extra_offset=offset, **parameters)
+        
+        self.edgecolors = [(0.0, 0.0, 0.0, 0.0) if mask == 1 else 'black' for mask in remove_edgecolor_mask]
+        self.ax = ax
+        self.figure = ax.figure
+        self.ax.set_aspect('equal')
+
+    def write(self):
+        self.write_body()
+        self.ax.set_xlim(0, self.w)
+        self.ax.set_ylim(0, self.h)
+
+    def write_body(self):
+        patch_list = make_patch_list(self)
+        for patch in patch_list:
+            self.ax.add_patch(patch)
+
+def make_patch_list(writer):
+    indices = writer.positions[:, 2].argsort()
+    patch_list = []
+    for a in indices:
+        xy = writer.positions[a, :2]
+        if a < writer.natoms:
+            r = writer.d[a] / 2
+            if ((xy[1] + r > 0) and (xy[1] - r < writer.h) and
+                (xy[0] + r > 0) and (xy[0] - r < writer.w)):
+                patch = Circle(xy, r, facecolor=writer.colors[a],
+                                edgecolor=writer.edgecolors[a])
+                patch_list.append(patch)
+        else:
+            a -= writer.natoms
+            c = writer.T[a]
+            if c != -1:
+                hxy = writer.D[c]
+                patch = PathPatch(Path((xy + hxy, xy - hxy)))
+                patch_list.append(patch)
+    return patch_list


### PR DESCRIPTION
Reworks `SamplePlotter` to create matplotlib patches with correct `facecolor`s and `edgecolor`s from scratch, rather than generating the patches with ASE's interface and modifying thousands of patches afterwards.

Reimplements a bit of ASE's matplotlib integration to make this work, as their version has no way of passing `edgecolor`s. This has allowed for stripping some unnecessary bits out, since they won't be used by this implementation.

Overall results in a ~3.5x plotting speed increase over the old method.