### PR TITLE
Add option for rejecting undercoordinated adsorbates

### DIFF
--- a/asesurfacefinder/utils.py
+++ b/asesurfacefinder/utils.py
@@ -1,5 +1,9 @@
+from asesurfacefinder.sample_bounds import SampleBounds
+
 from dscribe.descriptors import LMBTR, SOAP
 import numpy as np
+from ase.build import add_adsorbate
+from ase.geometry.analysis import Analysis
 
 from ase import Atoms
 from numpy.typing import ArrayLike
@@ -152,3 +156,17 @@ def _get_surface_idxs(slab: Atoms, base_surface: Atoms, tol: float=5e-2):
             slab_surf_idxs.append(reduced_to_full_idxmap[i])
 
     return slab_surf_idxs
+
+
+def get_site_coordination(surface: Atoms, site: str, bounds: SampleBounds):
+    '''Determines expected coordination of adsorbate atoms on a surface site.
+
+    Places a hydrogen atom at a site's `bounds.z_min` and checks its 
+    connectivity to the surface to establish a site coordination number.
+    '''
+    slab = surface.copy()
+    add_adsorbate(slab, 'H', bounds.z_min, site)
+    ana = Analysis(slab, self_interaction=False, bothways=True)
+    nl = ana.nl[0]
+    coord = len(nl.get_neighbors(len(slab)-1)[0])
+    return coord


### PR DESCRIPTION
Some adsorbates can contain atoms that lie close to the surface, but should not be considered as 'adsorbed', e.g. hydrogens bonded to actually chemisorbed atoms:

![Side view of CH3CH2NH- on Pt FCC(100)](https://github.com/user-attachments/assets/61e20f31-42f4-4539-8cf2-68b936113364)

Here the nitrogen is correctly detected on an `ontop` site of Pt FCC{100}, but its attached hydrogen (left) is detected as being adsorbed in a `bridge` site:

```python
{
    2: {'site': 'Pt_fcc100_ontop', 'bonded_elem': 'N', 'coordination': 1, 'height': 1.9993630699999994}, 
    8: {'site': 'Pt_fcc100_bridge', 'bonded_elem': 'H', 'coordination': 1, 'height': 2.0844453000000005}
}
```

Notably, the `bridge` hydrogen is detected to have a coordination of 1, rather than the expected coordination of 2 for a `bridge` site. This can be exploited to selectively reject adsorption predictions when 

1. coordination of a site doesn't match its expected value
2. undercoordinated atoms are directly bonded to an adsorbed atom that is correctly coordinated

This second point is crucial, as it could otherwise result in rejection of all adsorbed atoms in situations where two atoms are sharing a single site and are both equally undercoordinated.

This has been added as an option to `SurfaceFinder.predict()`: `reject_wrong_coordination: Bool` (default `False`). As a side effect, `SurfaceFinder` objects now track each surface's sites' expected coordination from initialisation. This is determined automatically by placing a hydrogen atom at the site's lower sampling bound and checking its coordination. To work around this 'correct' coordination being miscalculated (e.g. `SurfaceFinder.predict` with `nl_cutoffs` set to larger values than would be used during this initialisation may think predicted coordinations should be larger), per-site coordinations can also be specified manually with the `site_coordinations` argument to `SurfaceFinder()`, which overrides the automatically calculated value.